### PR TITLE
fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Shadps4 can load some modules in lle mode, some are neccesary some have HLE repl
 - libSceUlt.sprx
 - libSceCesCs.sprx
 - libSceFont.sprx
-- libSceRazorCpu.srpx
+- libSceRazorCpu.sprx
 - libSceRudp.sprx
 
 Above modules should be extracted from your ps4 . We don't provide any info or support of how to do it.


### PR DESCRIPTION
fixed a typo on a sys module where it said libSceRazorCpu.srpx instead of libSceRazorCpu.sprx