### PR TITLE
Verify Compatibility Data file size

### DIFF
--- a/.github/workflows/update_game_compatibility.yml
+++ b/.github/workflows/update_game_compatibility.yml
@@ -91,6 +91,18 @@ jobs:
           # Save the final JSON
           echo "$COMPATIBILITY_DATABASE" > compatibility_data.json
 
+      - name: Verify Compatibility Data file size
+        run: |
+          FILE_SIZE=$(stat -c %s compatibility_data.json)
+          MAX_FILE_SIZE=307200  # 300 KB in bytes
+
+          if [ "$FILE_SIZE" -lt "$MAX_FILE_SIZE" ]; then
+            echo "Compatibility data file is too small ($FILE_SIZE bytes), skipping release creation."
+            exit 0  # Exit the job to prevent further steps
+          else
+            echo "Compatibility data file is valid ($FILE_SIZE bytes). Proceeding with release creation."
+          fi
+
       - name: Delete all releases and tags
         run: |
           # List all releases


### PR DESCRIPTION
I believe that due to some instability in GitHub, the 'action' was unable to access the pages and generated an empty file.

This PR should ensure that it should only delete and create a new release if the file is larger than 300 kb.


![image](https://github.com/user-attachments/assets/67ab45f0-6f39-4c9d-8df9-722e32d6a601)

![image](https://github.com/user-attachments/assets/776bb85f-d08d-4396-96ca-e76827ebbc1d)
