### PR TITLE
Improve Rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -6,7 +6,7 @@ body:
       value: |
         ## Important: Read First
         - We only accept tests on major releases and not nightly builds. For example: 0.6.0 and not 0.6.1 WIP
-        - Only test games or homebrew made for the PlayStation 4. You can find a list of games here: https://www.serialstation.com/games/
+        - Only test officially released Playstation 4 games. You can find a list of games here: https://www.serialstation.com/games/
         - You've made sure there are no other issues opened for this game and operating system combo.
         - Your game dump must come from a copy of the game you own.
         - Your game dump must be unmodified, and you must not enable any game patches.

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -5,11 +5,12 @@ body:
     attributes:
       value: |
         ## Important: Read First
-        - We only accept test on major release and not nightly build. For Example: 0.6.0 and not 0.6.1 WIP
-        - Only games or homebrew made expressly for the PlayStation 4. You can check here: https://www.serialstation.com/games/
+        - We only accept tests on major release and not nightly build. For Example: 0.6.0 and not 0.6.1 WIP
+        - Only test games or homebrew made for the PlayStation 4. You can find a list of games here: https://www.serialstation.com/games/
         - By opening a new topic, you affirm that you have checked that it has not already been tested.
         - You must own your game, it must come from your own dump.
-        - Make sure your log is set to "Sync" and not "Async".
+        - Your game dump must be unmodified, and you must not enable any game patches.
+        - Make sure your log is set to "sync" and not "async".
   - type: input
     id: game-name
     attributes:

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -5,10 +5,10 @@ body:
     attributes:
       value: |
         ## Important: Read First
-        - We only accept tests on major release and not nightly build. For Example: 0.6.0 and not 0.6.1 WIP
+        - We only accept tests on major releases and not nightly builds. For example: 0.6.0 and not 0.6.1 WIP
         - Only test games or homebrew made for the PlayStation 4. You can find a list of games here: https://www.serialstation.com/games/
-        - By opening a new topic, you affirm that you have checked that it has not already been tested.
-        - You must own your game, it must come from your own dump.
+        - You've made sure there are no other issues opened for this game and operating system combo.
+        - Your game dump must come from a copy of the game you own.
         - Your game dump must be unmodified, and you must not enable any game patches.
         - Make sure your log is set to "sync" and not "async".
   - type: input
@@ -96,7 +96,7 @@ body:
     id: log
     attributes:
       label: Log File
-      description: Logs files can be found at user/log. Make sure it is set to "Sync" in the emulator options.
+      description: Logs files can be found at user/log. Make sure it is set to "sync" in the emulator options.
       placeholder: Drag and drop the log file onto the text area.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -10,7 +10,7 @@ body:
         - You've made sure there are no other issues opened for this game and operating system combo.
         - Your game dump must come from a copy of the game you own.
         - Your game dump must be unmodified, and you must not enable any game patches.
-        - Make sure your log is set to "sync" and not "async".
+        - Make sure your logging type is set to "sync" and not "async".
   - type: input
     id: game-name
     attributes:
@@ -96,7 +96,7 @@ body:
     id: log
     attributes:
       label: Log File
-      description: Logs files can be found at user/log. Make sure it is set to "sync" in the emulator options.
+      description: Log files can be found in the user/log folder. Make sure the logging type is set to "sync" in the emulator settings.
       placeholder: Drag and drop the log file onto the text area.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -73,7 +73,7 @@ body:
       label: Error
       placeholder: (Leave blank if status is playable) Don't describe what is happening but copy and paste the error in the last lines of log (Often it starts with [Debug] <Critical>)
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: emulation-description

--- a/README.md
+++ b/README.md
@@ -25,16 +25,15 @@
 
 - Only publish results from major [**shadPS4 releases**](https://github.com/shadps4-emu/shadPS4/releases) (e.g. 0.6.0).
 - Make sure you put all the necessary information: **Title**, **Game ID**, **Game Version**, **Emulator Version**, **Compatibility Status** and **Operating System**.
-- Don't edit posts, just reply to them. That way we can check what's changed from previous version.
 - Since compatibility between different OS varies, we allow one report per system-OS (Windows, Linux and macOS). So duplicate entries can exist if they are for different OS.
 - You can publish the same game only if the CUSA is different (e.g. Bloodborne = CUSA00900 & CUSA03173)
+- If the CUSA is the same as an older report, comment on the older report with the game's new status, a description of how it behaved, any screenshots you took, and a log.
 - Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed.
 
-## Informations
+## Information:
 
 shadPS4 can load some modules in **LLE** mode, some are necessary and some have **HLE** replacements.\
-The following firmware modules are supported and must be placed under `user/sys_modules` folder.\
-Tested firmware modules are from **11.00**.
+The following firmware modules are supported and must be placed in the `user/sys_modules` folder.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - Don't edit posts, just reply to them. That way we can check what's changed from previous version.
 - Since compatibility between different OS varies, we allow one report per system-OS (Windows, Linux and macOS). So duplicate entries can exist if they are for different OS.
 - You can publish the same game only if the CUSA is different (e.g. Bloodborne = CUSA00900 & CUSA03173)
+- Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed.
 
 ## Informations
 


### PR DESCRIPTION
Cleans up the grammar of our rules, and adds a rule about performing tests on unmodified game dumps.
We've been closing or removing reports with game patches applied or mods applied for a while, but never actually listed this rule.