### PR TITLE
Adding info about repackaged dumps to fpkgs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -9,7 +9,7 @@ body:
         - Only test officially released Playstation 4 games. You can find a list of games here: https://www.serialstation.com/games/
         - You've made sure there are no other issues opened for this game and operating system combo.
         - Your game dump must come from a copy of the game you own.
-        - Your game dump must be unmodified, and you must not enable any game patches. Dumps repackaged to fpkgs will be treated the same way.
+        - Your game dump must be unmodified, and you must not enable any game patches. Dumps repackaged to FPKGs will be treated the same way.
         - Make sure your logging type is set to "sync" and not "async".
   - type: input
     id: game-name

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -9,7 +9,7 @@ body:
         - Only test officially released Playstation 4 games. You can find a list of games here: https://www.serialstation.com/games/
         - You've made sure there are no other issues opened for this game and operating system combo.
         - Your game dump must come from a copy of the game you own.
-        - Your game dump must be unmodified, and you must not enable any game patches.
+        - Your game dump must be unmodified, and you must not enable any game patches. Dumps repackaged to fpkgs will be treated the same way.
         - Make sure your logging type is set to "sync" and not "async".
   - type: input
     id: game-name

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Since compatibility between different OS varies, we allow one report per system-OS (Windows, Linux and macOS). So duplicate entries can exist if they are for different OS.
 - You can publish the same game only if the CUSA is different (e.g. Bloodborne = CUSA00900 & CUSA03173)
 - If the CUSA is the same as an older report, comment on the older report with the game's new status, a description of how it behaved, any screenshots you took, and a log.
-- Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed.
+- Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed. Repackaging your dumps to fpkgs will be treated the same way.
 
 ## Information:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Since compatibility between different OS varies, we allow one report per system-OS (Windows, Linux and macOS). So duplicate entries can exist if they are for different OS.
 - You can publish the same game only if the CUSA is different (e.g. Bloodborne = CUSA00900 & CUSA03173)
 - If the CUSA is the same as an older report, comment on the older report with the game's new status, a description of how it behaved, any screenshots you took, and a log.
-- Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed. Repackaging your dumps to fpkgs will be treated the same way.
+- Only publish reports with unmodified game dumps. If any patches or modifications are applied, the report will be removed. Repackaging your dumps to FPKGs will be treated the same way.
 
 ## Information:
 


### PR DESCRIPTION
Adding info in the rules, stating that dumps repackaged to fpkgs with an external tool will be considered bad dumps as they modify the files.