### PR TITLE
Grammar Fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -12,7 +12,7 @@ body:
       options:
         - label: I've tested on a major release and not on a nightly build (In this case 0.7.0 and not 0.7.1 WIP).
           required: true
-        - label: My report is made on an officially released Playstation 4 game. (You can find a list of official Playstation 4 games [here](https://www.serialstation.com/games/))
+        - label: My report is made on an officially released PlayStation 4 game. (You can find a list of official PlayStation 4 games [here](https://www.serialstation.com/games/))
           required: true
         - label: I've made sure there are no other issues opened for this game and operating system combo.
           required: true

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ## Information:
 
-shadPS4 can load some PlayStation 4 firmware files, these must be dumped from your legally owned Playstation 4 console.\
+shadPS4 can load some PlayStation 4 firmware files, these must be dumped from your legally owned PlayStation 4 console.\
 The following firmware modules are supported and must be placed in shadPS4's `user/sys_modules` folder.
 
 <div align="center">


### PR DESCRIPTION
In a couple places, the capitalization of PlayStation is incorrect.